### PR TITLE
:green_heart: Fix for MacOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -57,7 +57,9 @@ jobs:
         run: >
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-      - name: Install Libraries
+      # macOS 11 is no longer supported
+      - if: matrix.os != 'macos-11'
+        name: Install Libraries
         run: >
           brew update &&
           brew install boost tbb

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -57,12 +57,17 @@ jobs:
         run: >
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-      # macOS 11 is no longer supported
-      - if: matrix.os != 'macos-11'
-        name: Install Libraries
+        name: Install Boost
         run: >
           brew update &&
-          brew install boost tbb
+          brew install boost
+
+      # TBB doesn't support macOS 11 anymore
+      - if: matrix.os != 'macos-11'
+        name: Install TBB
+        run: >
+          brew update &&
+          brew install tbb
 
       - name: Clone Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the github workflow after some MacOS 11 support was discontinued.