### PR TITLE
:construction_worker: Fix missing mnt-logo installation in cmakelists 

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -27,5 +27,6 @@ foreach (filename ${FILENAMES})
 
     # Install the executable and the physeng file
     install(TARGETS ${plugin} RUNTIME DESTINATION ${PLUGIN_INSTALL_DIR})
-    install(FILES ${plugin}/${plugin}.physeng DESTINATION ${PLUGIN_INSTALL_DIR})
+    install(FILES ${plugin}/${plugin}.physeng ${plugin}/logo-mnt.png DESTINATION ${PLUGIN_INSTALL_DIR})
+
 endforeach ()


### PR DESCRIPTION
## Description

This PR resolves the issue of the missing mnt-logo command in the install target within the CMakeLists. Adding this command ensures proper illustration of the MNT logo in _SiQAD_.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
