### PR TITLE
🚸 Improve ease of use for building ClusterComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ git clone --recursive https://github.com/cda-tum/mnt-siqad-plugins.git
 > Inside the newly cloned `mnt-siqad-plugins` folder, trigger the build process:
 
 ```bash
-cmake . -B build -DFICTION_Z3=OFF -DFICTION_BENCHMARK=OFF -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF
+cmake . -B build
 cd build
 cmake --build . -j4
 ```

--- a/README.md
+++ b/README.md
@@ -80,13 +80,19 @@ git clone --recursive https://github.com/cda-tum/mnt-siqad-plugins.git
 ```bash
 cmake . -B build
 cd build
-cmake --build . -j4
+cmake --build . -j4  # replace "4" with the number of CPU cores you want to use for the build process
 ```
 
-> **NB:** When building *ClusterComplete*, it is required to additionally pass `-DFICTION_ALGLIB=ON`. Furthermore,
-  *ClusterComplete* can be made significantly faster by passing `-DFICTION_ENABLE_JEMALLOC=ON`, although this CMake
-  option should not be passed when building *QuickSim*. See more information
-  [here](https://fiction.readthedocs.io/en/latest/getting_started.html#usage-of-jemalloc).
+#### Building a faster *ClusterComplete* binary 
+
+> *ClusterComplete* can be made significantly faster by passing `-DFICTION_ENABLE_JEMALLOC=ON`, i.e.:
+```bash
+cmake . -B build -DFICTION_ENABLE_JEMALLOC=ON
+cd build
+cmake --build . -j4
+```
+> **NB:** This CMake option should not be passed when building *QuickSim* as it has an adverse effect on the runtime for this plugin. 
+> Find more information [here](https://fiction.readthedocs.io/en/latest/getting_started.html#usage-of-jemalloc).
 
 ### Using *ClusterComplete*, *QuickExact* and *QuickSim* in the SiQAD GUI
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -6,6 +6,7 @@ set(FICTION_TEST OFF CACHE BOOL "" FORCE)
 set(FICTION_EXPERIMENTS OFF CACHE BOOL "" FORCE)
 set(FICTION_PROGRESS_BARS OFF CACHE BOOL "" FORCE)
 set(FICTION_ALGLIB ON CACHE BOOL "" FORCE)  # Enable ALGLIB by default to support ClusterComplete
+set(MOCKTURTLE_EXAMPLES OFF CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fiction)
 target_link_libraries(mnt-siqad-plugins-dependencies INTERFACE libfiction)
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -5,6 +5,7 @@ set(FICTION_CLI OFF CACHE BOOL "" FORCE)
 set(FICTION_TEST OFF CACHE BOOL "" FORCE)
 set(FICTION_EXPERIMENTS OFF CACHE BOOL "" FORCE)
 set(FICTION_PROGRESS_BARS OFF CACHE BOOL "" FORCE)
+set(FICTION_ALGLIB ON CACHE BOOL "" FORCE)  # Enable ALGLIB by default to support ClusterComplete
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fiction)
 target_link_libraries(mnt-siqad-plugins-dependencies INTERFACE libfiction)
 


### PR DESCRIPTION
## Description

This PR sets two new defaults: `-DMOCKTURTLE_EXAMPLES=OFF`  and `-DFICTION_ALGLIB=ON`. This way, the user does not need to bother with CMake arguments to have all the plugins ready to build. 

The README is updated accordingly.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
