### PR TITLE
:arrow_up: Updated CI to remove deprecated Windows 2019 version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,28 +19,19 @@ on:
       - '**/CMakeLists.txt'
       - 'libs/**'
       - '.github/workflows/windows.yml'
-    merge_group:
+  merge_group:
 
 jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ windows-2019, windows-2022, windows-2025 ]
-        toolset: [ v142, v143, ClangCL ]
+        os: [ windows-2022, windows-2025 ]
+        toolset: [ v143, ClangCL ]
         include:
-          - os: windows-2019
-            env: "Visual Studio 16 2019"
           - os: windows-2022
             env: "Visual Studio 17 2022"
           - os: windows-2025
             env: "Visual Studio 17 2022"
-        exclude:
-          - os: windows-2019
-            toolset: v143
-          - os: windows-2022
-            toolset: v142
-          - os: windows-2025
-            toolset: v142
 
     name: 🪟 ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
## Description

Removed support for `windows-2019` and the `v142` toolset from the matrix strategy, simplifying the configuration to focus on more recent environments (`windows-2022` and `windows-2025`).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
